### PR TITLE
NSA-995 - Add patch to invitation to support completing

### DIFF
--- a/src/app/invitations/api/index.js
+++ b/src/app/invitations/api/index.js
@@ -6,6 +6,7 @@ const config = require('./../../../infrastructure/config');
 const postInvitations = require('./postInvitations');
 const getInvitations = require('./getInvitations');
 const createUser = require('./createUser');
+const patchInvitation = require('./patchInvitation');
 const assert = require('assert');
 
 const router = express.Router();
@@ -20,6 +21,7 @@ const routeExport = () => {
   // Map routed to functions.
   router.post('/', postInvitations);
   router.get('/:id', getInvitations);
+  router.patch('/:id', patchInvitation);
   router.post('/:id/create_user', createUser);
   return router;
 };

--- a/src/app/invitations/api/patchInvitation.js
+++ b/src/app/invitations/api/patchInvitation.js
@@ -1,0 +1,40 @@
+const { getUserInvitation, updateInvitation } = require('./../data/redisInvitationStorage');
+
+const patchableProperties = ['isCompleted'];
+const patchablePropertiesMessage = patchableProperties.concat();
+
+const validatePatchProperties = (req) => {
+  const patchProperties = req.body ? Object.keys(req.body) : [];
+  if (patchProperties.length === 0) {
+    return 'No properties specified for patching';
+  }
+
+  const propertyError = patchProperties.map((property) => {
+    if (!patchableProperties.find(x => x === property)) {
+      return `Invalid property patched - ${property}. Patchable properties are ${patchablePropertiesMessage}`;
+    }
+    return null;
+  }).find(x => x !== null);
+  if (propertyError) {
+    return propertyError;
+  }
+};
+
+const patchInvitation = async (req, res) => {
+  const invitation = await getUserInvitation(req.params.id, req.header('x-correlation-id'));
+  if (!invitation) {
+    return res.status(404).send();
+  }
+
+  const requestError = validatePatchProperties(req);
+  if (requestError) {
+    return res.status(400).send(requestError);
+  }
+
+  const patchedInvitation = Object.assign(invitation, req.body);
+  await updateInvitation(patchedInvitation);
+
+  return res.status(202).send();
+};
+
+module.exports = patchInvitation;

--- a/src/app/invitations/data/redisInvitationStorage.js
+++ b/src/app/invitations/data/redisInvitationStorage.js
@@ -14,6 +14,12 @@ const find = async (id) => {
   return invitation || null;
 };
 
+const storeInvitation = async (invitation) => {
+  const content = JSON.stringify(invitation);
+
+  await client.set(`UserInvitation_${invitation.id}`, content);
+  return JSON.parse(content);
+};
 
 const createInvitation = async (invitation) => {
   if (!invitation) {
@@ -23,10 +29,8 @@ const createInvitation = async (invitation) => {
   const newInvitation = invitation;
 
   newInvitation.id = id;
-  const content = JSON.stringify(newInvitation);
 
-  await client.set(`UserInvitation_${id}`, content);
-  return JSON.parse(content);
+  return await storeInvitation(newInvitation);
 };
 
 const deleteInvitationForUser = async (id) => {
@@ -68,9 +72,19 @@ const deleteInvitation = async (id, correlationId) => {
   }
 };
 
+const updateInvitation = async (invitation, correlationId) => {
+  try {
+    await storeInvitation(invitation);
+  } catch (e) {
+    logger.error(`Update invitation failed for request ${correlationId} error: ${e}`, { correlationId });
+    throw e;
+  }
+};
+
 
 module.exports = {
   deleteInvitation,
   createUserInvitation,
   getUserInvitation,
+  updateInvitation,
 };

--- a/test/invitationsTests/patchInvitation.test.js
+++ b/test/invitationsTests/patchInvitation.test.js
@@ -1,0 +1,97 @@
+jest.mock('./../../src/app/invitations/data/redisInvitationStorage', () => {
+  return {
+    getUserInvitation: jest.fn(),
+    updateInvitation: jest.fn(),
+  };
+});
+
+const httpMocks = require('node-mocks-http');
+const { getUserInvitation, updateInvitation } = require('./../../src/app/invitations/data/redisInvitationStorage');
+const patchInvitation = require('./../../src/app/invitations/api/patchInvitation');
+
+describe('When patching an invitation', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {
+      params: {
+        id: '714d039d-92f7-4bc4-9422-63d194a7',
+      },
+      header: () => 'x-correlation-id',
+      body: {
+        isCompleted: true,
+      },
+    };
+
+    res = httpMocks.createResponse();
+
+    getUserInvitation.mockReset();
+    getUserInvitation.mockReturnValue({
+      email: 'severus.snape@hogwarts.test',
+      firstName: 'Severus',
+      lastName: 'Snape',
+      oldCredentials: {
+        source: 'OSA',
+        username: 'snape',
+        password: 'hashed-password',
+        salt: 'some-salt',
+        tokenSerialNumber: '1234567890',
+      },
+      id: '714d039d-92f7-4bc4-9422-63d194a7',
+    });
+  });
+
+  it('then it should return 400 - Bad request if no keys in body', async () => {
+    req.body = {};
+
+    await patchInvitation(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getData()).toBe('No properties specified for patching');
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('then it should return 400 - Bad request if invalid key specified in body', async () => {
+    req.body = {
+      isCompleted: true,
+      bad1: 1,
+      bad2: false,
+    };
+
+    await patchInvitation(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getData()).toBe('Invalid property patched - bad1. Patchable properties are isCompleted');
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('then it should return 404 - Not found if invitation is not found', async () => {
+    getUserInvitation.mockReturnValue(null);
+
+    await patchInvitation(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('then it should store patched invitation', async () => {
+    await patchInvitation(req, res);
+
+    expect(updateInvitation.mock.calls).toHaveLength(1);
+    expect(updateInvitation.mock.calls[0][0]).toMatchObject({
+      email: 'severus.snape@hogwarts.test',
+      firstName: 'Severus',
+      lastName: 'Snape',
+      oldCredentials: {
+        source: 'OSA',
+        username: 'snape',
+        password: 'hashed-password',
+        salt: 'some-salt',
+        tokenSerialNumber: '1234567890',
+      },
+      id: '714d039d-92f7-4bc4-9422-63d194a7',
+      isCompleted: true,
+    });
+  });
+});


### PR DESCRIPTION
Invitation supports patching isCompleted to allow for invitations to be marked as complete and not reused