### PR TITLE
NSA-1384 - Allow email to be updated on invitation

### DIFF
--- a/src/app/invitations/api/patchInvitation.js
+++ b/src/app/invitations/api/patchInvitation.js
@@ -1,6 +1,10 @@
+const config = require('./../../../infrastructure/config');
 const { getUserInvitation, updateInvitation } = require('./../data/redisInvitationStorage');
+const { generateInvitationCode } = require('./../utils');
+const NotificationClient = require('login.dfe.notifications.client');
+const { getOidcClientById } = require('./../../../infrastructure/hotConfig');
 
-const patchableProperties = ['isCompleted', 'deactivated', 'reason'];
+const patchableProperties = ['email', 'isCompleted', 'deactivated', 'reason'];
 const patchablePropertiesMessage = patchableProperties.concat();
 
 const validatePatchProperties = (req) => {
@@ -19,6 +23,23 @@ const validatePatchProperties = (req) => {
     return propertyError;
   }
 };
+const sendInvitation = async (invitation) => {
+  const notificationClient = new NotificationClient({
+    connectionString: config.notifications.connectionString,
+  });
+
+  const client = invitation.origin ? await getOidcClientById(invitation.origin.clientId) : undefined;
+  let friendlyName;
+  let digipassRequired = false;
+  if (client) {
+    friendlyName = client.friendlyName;
+    digipassRequired = client.params ? client.params.digipassRequired : false;
+  }
+
+  await notificationClient.sendInvitation(
+    invitation.email, invitation.firstName, invitation.lastName, invitation.id, invitation.code,
+    friendlyName, digipassRequired, invitation.selfStarted);
+};
 
 const patchInvitation = async (req, res) => {
   const invitation = await getUserInvitation(req.params.id, req.header('x-correlation-id'));
@@ -31,8 +52,15 @@ const patchInvitation = async (req, res) => {
     return res.status(400).send(requestError);
   }
 
-  const patchedInvitation = Object.assign(invitation, req.body);
+  const patchedInvitation = Object.assign(Object.assign({}, invitation), req.body);
+  const emailHasChanged = patchedInvitation.email.toLowerCase() !== invitation.email.toLowerCase();
+  if (emailHasChanged) {
+    patchedInvitation.code = generateInvitationCode();
+  }
   await updateInvitation(patchedInvitation);
+  if (emailHasChanged) {
+    await sendInvitation(patchedInvitation);
+  }
 
   return res.status(202).send();
 };

--- a/test/invitationsTests/patchInvitation.test.js
+++ b/test/invitationsTests/patchInvitation.test.js
@@ -1,17 +1,39 @@
+jest.mock('./../../src/infrastructure/config', () => ({
+  redis: {
+    url: 'http://orgs.api.test',
+  },
+  notifications: {
+    connectionString: '',
+  },
+  hotConfig: {
+    type: 'static',
+  },
+}));
 jest.mock('./../../src/app/invitations/data/redisInvitationStorage', () => {
   return {
     getUserInvitation: jest.fn(),
     updateInvitation: jest.fn(),
   };
 });
+jest.mock('./../../src/app/invitations/utils', () => {
+  return {
+    generateInvitationCode: jest.fn(),
+  };
+});
+jest.mock('login.dfe.notifications.client');
+jest.mock('./../../src/infrastructure/hotConfig');
 
 const httpMocks = require('node-mocks-http');
+const notificationClient = require('login.dfe.notifications.client');
 const { getUserInvitation, updateInvitation } = require('./../../src/app/invitations/data/redisInvitationStorage');
+const { generateInvitationCode } = require('./../../src/app/invitations/utils');
+const { getOidcClientById } = require('./../../src/infrastructure/hotConfig');
 const patchInvitation = require('./../../src/app/invitations/api/patchInvitation');
 
 describe('When patching an invitation', () => {
   let req;
   let res;
+  let sendInvitationStub;
 
   beforeEach(() => {
     req = {
@@ -31,15 +53,42 @@ describe('When patching an invitation', () => {
       email: 'severus.snape@hogwarts.test',
       firstName: 'Severus',
       lastName: 'Snape',
-      oldCredentials: {
-        source: 'OSA',
-        username: 'snape',
-        password: 'hashed-password',
-        salt: 'some-salt',
-        tokenSerialNumber: '1234567890',
+      origin: {
+        clientId: 'client1',
+        redirectUri: 'https://example.com',
       },
+      selfStarted: false,
+      code: 'existing-code',
       id: '714d039d-92f7-4bc4-9422-63d194a7',
     });
+
+    generateInvitationCode.mockReset().mockReturnValue('new-code');
+
+    getOidcClientById.mockReset().mockImplementation((id) => {
+      if (id !== 'client1') {
+        return undefined;
+      }
+      return {
+        client_id: 'client1',
+        client_secret: 'some-secure-secret',
+        redirect_uris: [
+          'https://client.one/auth/cb',
+          'https://client.one/register/complete',
+        ],
+        post_logout_redirect_uris: [
+          'https://client.one/signout/complete',
+        ],
+        params: {
+          digipassRequired: true,
+        },
+        friendlyName: 'Client One',
+      };
+    });
+
+    sendInvitationStub = jest.fn();
+    notificationClient.mockReset().mockImplementation(() => ({
+      sendInvitation: sendInvitationStub,
+    }));
   });
 
   it('then it should return 400 - Bad request if no keys in body', async () => {
@@ -62,7 +111,7 @@ describe('When patching an invitation', () => {
     await patchInvitation(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getData()).toBe('Invalid property patched - bad1. Patchable properties are isCompleted,deactivated,reason');
+    expect(res._getData()).toBe('Invalid property patched - bad1. Patchable properties are email,isCompleted,deactivated,reason');
     expect(res._isEndCalled()).toBe(true);
   });
 
@@ -96,15 +145,84 @@ describe('When patching an invitation', () => {
       email: 'severus.snape@hogwarts.test',
       firstName: 'Severus',
       lastName: 'Snape',
-      oldCredentials: {
-        source: 'OSA',
-        username: 'snape',
-        password: 'hashed-password',
-        salt: 'some-salt',
-        tokenSerialNumber: '1234567890',
+      origin: {
+        clientId: 'client1',
+        redirectUri: 'https://example.com',
       },
+      selfStarted: false,
+      code: 'existing-code',
       id: '714d039d-92f7-4bc4-9422-63d194a7',
       isCompleted: true,
     });
+  });
+
+  it('then it allows email to be patched', async () => {
+    req.body = {
+      email: 'new.email@unit.test',
+    };
+
+    await patchInvitation(req, res);
+
+    expect(res.statusCode).toBe(202);
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('then it should update email if email has changed', async () => {
+    req.body = {
+      email: 'new.email@unit.test',
+    };
+
+    await patchInvitation(req, res);
+
+    expect(updateInvitation.mock.calls).toHaveLength(1);
+    expect(updateInvitation.mock.calls[0][0]).toMatchObject({
+      email: 'new.email@unit.test',
+    });
+  });
+
+  it('then it should update invitation code if email has changed', async () => {
+    req.body = {
+      email: 'new.email@unit.test',
+    };
+
+    await patchInvitation(req, res);
+
+    expect(updateInvitation.mock.calls).toHaveLength(1);
+    expect(updateInvitation.mock.calls[0][0]).toMatchObject({
+      code: 'new-code',
+    });
+  });
+
+  it('then it should send invitation to new address with new code if email has changed', async () => {
+    req.body = {
+      email: 'new.email@unit.test',
+    };
+
+    await patchInvitation(req, res);
+
+    expect(sendInvitationStub.mock.calls).toHaveLength(1);
+    expect(sendInvitationStub.mock.calls[0][0]).toBe('new.email@unit.test');
+    expect(sendInvitationStub.mock.calls[0][1]).toBe('Severus');
+    expect(sendInvitationStub.mock.calls[0][2]).toBe('Snape');
+    expect(sendInvitationStub.mock.calls[0][3]).toBe('714d039d-92f7-4bc4-9422-63d194a7');
+    expect(sendInvitationStub.mock.calls[0][4]).toBe('new-code');
+    expect(sendInvitationStub.mock.calls[0][5]).toBe('Client One');
+    expect(sendInvitationStub.mock.calls[0][6]).toBe(true);
+    expect(sendInvitationStub.mock.calls[0][7]).toBe(false);
+  });
+
+  it('then it should not update invitation code if email has not changed', async () => {
+    await patchInvitation(req, res);
+
+    expect(updateInvitation.mock.calls).toHaveLength(1);
+    expect(updateInvitation.mock.calls[0][0]).toMatchObject({
+      code: 'existing-code',
+    });
+  });
+
+  it('then it should not send invitation if email has not changed', async () => {
+    await patchInvitation(req, res);
+
+    expect(sendInvitationStub.mock.calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Allow email to be patched on invitation. If changed then it will generate new code and send invitation again