### PR TITLE
[NSA-2214] Intercept AlwaysOn requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const alwaysOnFilter = require('./middleware/alwaysOnFilter');
 const config = require('./infrastructure/config');
 const logger = require('./infrastructure/logger');
 const express = require('express');
@@ -32,13 +33,13 @@ https.GlobalAgent = new KeepAliveAgent({
   keepAliveTimeout: config.hostingEnvironment.agentKeepAlive.keepAliveTimeout,
 });
 
-
 configSchema.validate();
 
 const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
+app.use(alwaysOnFilter());
 
 app.use('/healthcheck', healthCheck({
   config,

--- a/src/middleware/alwaysOnFilter/index.js
+++ b/src/middleware/alwaysOnFilter/index.js
@@ -1,0 +1,10 @@
+// TODO Add to a general purpose request processing middleware lib
+const alwaysOnFilter = () => (req, res, next) => {
+  res.locals.ua = req.get('User-Agent');
+  if (res.locals.ua === 'AlwaysOn') {
+    return res.status(200).send();
+  }
+  return next();
+};
+
+module.exports = alwaysOnFilter;


### PR DESCRIPTION
The Always On feature of Azure constantly pings the root of the application. As the root requires authentication, this presents an error to Application Insights. This middleware intercepts the request (based on the user-agent) and returns a status 200 OK.

Ideally, should be pulled out to a supporting lib as a dependency, so that it can be utilised in other applications. TBC!