### PR TITLE
[NSA-5577] Added last_login property to safeUser function

### DIFF
--- a/src/utils/safeUser.js
+++ b/src/utils/safeUser.js
@@ -2,7 +2,6 @@
 
 const { pick } = require('lodash');
 
-const safeUser = user => pick(user, ['sub', 'given_name', 'family_name', 'email', 'job_title', 'id', 'status', 'legacy_username', 'phone_number', 'isMigrated', 'password_reset_required']);
-
+const safeUser = user => pick(user, ['sub', 'given_name', 'family_name', 'email', 'job_title', 'id', 'status', 'legacy_username', 'phone_number', 'last_login', 'isMigrated', 'password_reset_required']);
 
 module.exports = safeUser;


### PR DESCRIPTION
Added last_login property to the safeUser util function, so Directories API calls take precedence over the last login datetime from audit.

Ticket in question: https://dfe-secureaccess.atlassian.net/browse/NSA-5577