### PR TITLE
Change `/users/:uid/match-phrase` endpoint from `GET` to `POST` since it expects a body in the request.

### DIFF
--- a/src/app/user/api/index.js
+++ b/src/app/user/api/index.js
@@ -42,7 +42,7 @@ const routeExport = () => {
   router.get('/users/by-legacyusername/:id', asyncWrapper(findByLegacyUsername));
   router.get('/users/:id', asyncWrapper(find));
   router.get('/users/:uid/legacy-username', asyncWrapper(findLegacyUsernamesById));
-  router.get('/users/:uid/match-phrase', asyncWrapper(matchedPassphrase));
+  router.post('/users/:uid/match-phrase', asyncWrapper(matchedPassphrase));
   router.get('/users/:uid/password-policies', asyncWrapper(getUserPasswordPolicies));
   router.get('/users/:uid/password-history', asyncWrapper(passwordHistory));
   router.post('/:directoryId/user/authenticate', deprecateWith('/users/authenticate'), asyncWrapper(authenticate));


### PR DESCRIPTION
The `login.dfe.interactions` service is currently making a `GET` request to this endpoint and providing a body in the request.

This is no longer working because of the switch from `request-promise` to `fetch` for initiating requests since `fetch` does not permit a body when making a `GET` request.

The intention of this PR is to turn this into a `POST` endpoint such that `fetch` can be used.

> **WARNING:** Do not merge this PR until the changes in `login.dfe.interactions` are ready to be merged.