### PR TITLE
[DSI-7245, DSI-7250] Update DSI User's associated Entra account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4161,16 +4161,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.0.tgz",
-      "integrity": "sha1-1Xy3BtSWI9SsJ4M/HLxGa2aOuRU=",
+      "version": "4.21.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.1.tgz",
+      "integrity": "sha1-na5d2oMvFrTuyUGk5EqonsSBsoE=",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4221,6 +4221,14 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha1-L3PEIULV1c9xMQp0/ErmFnDl28k=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2756,8 +2756,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "license": "MIT",
+      "version": "1.20.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha1-GVNDEiHG+1zWPEs21T+rCSjlSMY=",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -2767,7 +2768,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -3599,8 +3600,9 @@
       "license": "MIT"
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3750,7 +3752,8 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4060,7 +4063,8 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "license": "MIT",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4124,35 +4128,36 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "license": "MIT",
+      "version": "4.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.0.tgz",
+      "integrity": "sha1-1Xy3BtSWI9SsJ4M/HLxGa2aOuRU=",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -4341,11 +4346,12 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha1-DFdfHR0yTd0do1rX7OPffRkIgBk=",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -4358,14 +4364,16 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "license": "MIT",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -6433,8 +6441,12 @@
       "license": "MIT"
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha1-2AMZpl88eTU1Hlz9rI+TGFBNvtU=",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6457,11 +6469,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -7286,8 +7299,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "license": "MIT"
+      "version": "0.1.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha1-Z+kQjFwFUbnlMmBkOH3kdjxNX4s="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7740,10 +7754,11 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "license": "BSD-3-Clause",
+      "version": "6.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -8131,8 +8146,9 @@
       "license": "ISC"
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "license": "MIT",
+      "version": "0.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.19.0.tgz",
+      "integrity": "sha1-u8WjiMjqbASJZwSdvqwOSj8J1/g=",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8154,18 +8170,29 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "license": "MIT",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "license": "MIT"
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
     },
     "node_modules/sequelize": {
       "version": "6.37.2",
@@ -8242,13 +8269,14 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "license": "MIT",
+      "version": "1.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha1-tqU0PaR/a90mc4SL9FdUlB6AMpY=",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "login.dfe.audit.transporter": "^4.0.0",
         "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
+        "login.dfe.entra-auth-extensions": "^1.0.13",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
@@ -268,6 +269,24 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.5.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/functions/-/functions-4.5.1.tgz",
+      "integrity": "sha1-cNGpnTNa+HV5pV08FJ7xrnfaCmY=",
+      "dependencies": {
+        "cookie": "^0.6.0",
+        "long": "^4.0.0",
+        "undici": "^5.13.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/functions/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/long/-/long-4.0.0.tgz",
+      "integrity": "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg="
     },
     "node_modules/@azure/identity": {
       "version": "4.4.1",
@@ -1082,6 +1101,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha1-udpqh4o3GCmgUCybbBwUPvZmP00=",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "dev": true,
@@ -1838,7 +1865,6 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1847,7 +1873,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1862,7 +1887,6 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1873,7 +1897,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.19.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1892,7 +1915,6 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ioredis-mock": {
@@ -1943,9 +1965,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
+      "integrity": "sha1-5JuWwrKTVu1GLpcI/HO4MwFHJ9I=",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -1961,12 +1990,10 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/readable-stream": {
@@ -1988,7 +2015,6 @@
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1997,7 +2023,6 @@
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3573,6 +3598,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha1-uN+qXQ2uKPGwPJWIHZBNTkC/5+0=",
+      "engines": {
+        "node": ">4.0"
+      }
+    },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
       "license": "BSD-2-Clause",
@@ -4176,6 +4209,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express-validator/-/express-validator-7.2.0.tgz",
+      "integrity": "sha1-9gd3WHMtUuI2W7mDsauspRu++6Y=",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5963,6 +6008,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha1-m2jtop6aBhTAQvopOHGWx92AAQA=",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-md4": {
       "version": "0.3.2",
       "license": "MIT"
@@ -6082,6 +6135,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwks-rsa/-/jwks-rsa-3.1.0.tgz",
+      "integrity": "sha1-UEBvI+OMmyaCzUN/gk19YaqYMXE=",
+      "dependencies": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
+        "debug": "^4.3.4",
+        "jose": "^4.14.6",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/jws": {
       "version": "3.2.2",
       "license": "MIT",
@@ -6156,6 +6225,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha1-j5KiWzsWxhMSk6DMg0tKg4oqp8I="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -6285,6 +6359,19 @@
         "simpl-schema": "^3.4.1"
       }
     },
+    "node_modules/login.dfe.entra-auth-extensions": {
+      "version": "1.0.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.entra-auth-extensions/-/login.dfe.entra-auth-extensions-1.0.13.tgz",
+      "integrity": "sha1-+DqMKv+2OzsLT4gNUXB2+1PgXUE=",
+      "dependencies": {
+        "@azure/functions": "^4.0.0",
+        "@azure/msal-node": "^2.11.1",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
+        "login.dfe.validation": "github:DFE-Digital/login.dfe.validation#v2.1.2",
+        "validator": "^13.12.0"
+      }
+    },
     "node_modules/login.dfe.express-error-handling": {
       "version": "3.0.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#2b1de1f9e1cc8d14afff441ff97c344d9c6cbc86",
@@ -6384,6 +6471,14 @@
         "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.0"
       }
     },
+    "node_modules/login.dfe.validation": {
+      "version": "2.1.2",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.validation.git#5c3895f6b3059333199b55f847cfdba6dcd2a755",
+      "dependencies": {
+        "email-validator": "^2.0.4",
+        "express-validator": "^7.0.1"
+      }
+    },
     "node_modules/login.dfe.winston-appinsights": {
       "version": "5.0.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#fe50b019f8bd9b065808601ef85d95d431b075ba",
@@ -6406,6 +6501,31 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha1-7w+8AhvOtmZ5SxRe76xr5J3EfzE=",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -9072,6 +9192,17 @@
       "version": "1.13.6",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha1-aygECO22oaYEqbIDQPRbQi43MGg=",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "license": "MIT"
@@ -9175,8 +9306,9 @@
       "version": "1.0.9"
     },
     "node_modules/validator": {
-      "version": "13.11.0",
-      "license": "MIT",
+      "version": "13.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha1-fXjna6hVBNo/7k/Rkis4WRTUs18=",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "login.dfe.audit.transporter": "^4.0.0",
         "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-        "login.dfe.entra-auth-extensions": "^1.0.14",
+        "login.dfe.entra-auth-extensions": "^1.0.15",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
@@ -6368,9 +6368,9 @@
       }
     },
     "node_modules/login.dfe.entra-auth-extensions": {
-      "version": "1.0.14",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.entra-auth-extensions/-/login.dfe.entra-auth-extensions-1.0.14.tgz",
-      "integrity": "sha1-PY/24KsLXUBY/MgiYujSgstjb0E=",
+      "version": "1.0.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.entra-auth-extensions/-/login.dfe.entra-auth-extensions-1.0.15.tgz",
+      "integrity": "sha1-Khyvm+MenoDNq1Gju/U8m9Cb93U=",
       "dependencies": {
         "@azure/functions": "^4.0.0",
         "@azure/msal-node": "^2.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "login.dfe.audit.transporter": "^4.0.0",
         "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-        "login.dfe.entra-auth-extensions": "^1.0.13",
+        "login.dfe.entra-auth-extensions": "^1.0.14",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",
@@ -6360,9 +6360,9 @@
       }
     },
     "node_modules/login.dfe.entra-auth-extensions": {
-      "version": "1.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.entra-auth-extensions/-/login.dfe.entra-auth-extensions-1.0.13.tgz",
-      "integrity": "sha1-+DqMKv+2OzsLT4gNUXB2+1PgXUE=",
+      "version": "1.0.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.entra-auth-extensions/-/login.dfe.entra-auth-extensions-1.0.14.tgz",
+      "integrity": "sha1-PY/24KsLXUBY/MgiYujSgstjb0E=",
       "dependencies": {
         "@azure/functions": "^4.0.0",
         "@azure/msal-node": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "login.dfe.audit.transporter": "^4.0.0",
     "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-    "login.dfe.entra-auth-extensions": "^1.0.14",
+    "login.dfe.entra-auth-extensions": "^1.0.15",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "login.dfe.audit.transporter": "^4.0.0",
     "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
+    "login.dfe.entra-auth-extensions": "^1.0.13",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "login.dfe.audit.transporter": "^4.0.0",
     "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.2",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-    "login.dfe.entra-auth-extensions": "^1.0.13",
+    "login.dfe.entra-auth-extensions": "^1.0.14",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.0",

--- a/src/app/user/api/patchUser.js
+++ b/src/app/user/api/patchUser.js
@@ -1,7 +1,7 @@
-const { find, update } = require('./../adapter');
-const logger = require('./../../../infrastructure/logger');
-const { safeUser } = require('./../../../utils');
-const config = require('./../../../infrastructure/config');
+const { find, update } = require('../adapter');
+const logger = require('../../../infrastructure/logger');
+const { safeUser } = require('../../../utils');
+const config = require('../../../infrastructure/config');
 const ServiceNotificationsClient = require('login.dfe.service-notifications.jobs.client');
 
 const allowablePatchProperties = ['given_name', 'family_name', 'email', 'job_title', 'phone_number', 'legacyUsernames'];
@@ -10,16 +10,26 @@ const allowablePropertiesMessage = allowablePatchProperties.concat();
 const validateRequestData = (req) => {
   const keys = Object.keys(req.body);
   if (keys.length === 0) {
-    return `Must specify at least one property to update. Allowed properties ${allowablePropertiesMessage}`
+    return `Must specify at least one property to update. Allowed properties ${allowablePropertiesMessage}`;
   }
 
   const errorMessages = keys.map((key) => {
-    if (!allowablePatchProperties.find(x => x === key)) {
-      return `Unpatchable property ${key}. Allowed properties ${allowablePropertiesMessage}`
+    if (!allowablePatchProperties.find((x) => x === key)) {
+      return `Unpatchable property ${key}. Allowed properties ${allowablePropertiesMessage}`;
     }
     return null;
   });
-  return errorMessages.find(x => x !== null);
+  return errorMessages.find((x) => x !== null);
+};
+
+const sendNotification = async (user, updatedUser, correlationId) => {
+  if (config.toggles && config.toggles.notificationsEnabled) {
+    const serviceNotificationsClient = new ServiceNotificationsClient({
+      connectionString: config.notifications.connectionString,
+    });
+    const jobId = await serviceNotificationsClient.notifyUserUpdated(safeUser(updatedUser));
+    logger.info(`Send user updated notification for ${user.sub} with job id ${jobId} (reason: patch)`, { correlationId });
+  }
 };
 
 const patchUser = async (req, res) => {
@@ -39,19 +49,68 @@ const patchUser = async (req, res) => {
     return res.status(400).send(validationErrorMessage);
   }
 
+  const nameDetailsChanged = ['given_name', 'family_name'].some((property) => property in req.body && req.body[property].trim().toLowerCase() !== user[property].trim().toLowerCase());
+  const emailAddrressChanged = !!req.body.email && req.body.email.trim().toLowerCase() !== user.email.trim().toLowerCase();
+
   // Patch user
   const updatedUser = Object.assign(userModel, req.body);
-  await update(updatedUser.sub, updatedUser.given_name, updatedUser.family_name,
-    updatedUser.email, updatedUser.job_title, updatedUser.phone_number, updatedUser.legacyUsernames, correlationId);
+  await update(
+    updatedUser.sub,
+    updatedUser.given_name,
+    updatedUser.family_name,
+    updatedUser.email,
+    updatedUser.job_title,
+    updatedUser.phone_number,
+    updatedUser.legacyUsernames,
+    correlationId,
+  );
 
-  if (config.toggles && config.toggles.notificationsEnabled) {
-    const serviceNotificationsClient = new ServiceNotificationsClient({
-      connectionString: config.notifications.connectionString,
-    });
-    const jobId = await serviceNotificationsClient.notifyUserUpdated(safeUser(updatedUser));
-    logger.info(`Send user updated notification for ${user.sub} with job id ${jobId} (reason: patch)`, { correlationId });
+  if (!!user.is_entra && !!user.entra_oid) {
+    let nameChangeFailed = false;
+    let emailChangeFailed = false;
+
+    if (nameDetailsChanged === true) {
+      try {
+        await req.externalAuth.changeName({
+          userId: user.entra_oid,
+          firstName: updatedUser.given_name,
+          lastName: updatedUser.family_name,
+        });
+      } catch (error) {
+        nameChangeFailed = true;
+        logger.error(`patchUser req.externalAuth.changeName failed for user '${user.sub}' with entraOid ${user.entra_oid} for the reason(s) ${error} (correlationId: '${correlationId}')`, { correlationId });
+      }
+    }
+
+    if (emailAddrressChanged === true) {
+      try {
+        await req.externalAuth.changeEmail({
+          userId: user.entra_oid,
+          emailAddress: updatedUser.email,
+        });
+      } catch (error) {
+        emailChangeFailed = true;
+        logger.error(`patchUser req.externalAuth.changeEmail failed for user '${user.sub}' with entraOid ${user.entra_oid} for the reason(s) ${error} (correlationId: '${correlationId}')`, { correlationId });
+      }
+    }
+
+    if (nameChangeFailed === true || emailChangeFailed === true) {
+      await update(
+        updatedUser.sub,
+        nameChangeFailed ? user.given_name : updatedUser.given_name,
+        nameChangeFailed ? user.family_name : updatedUser.family_name,
+        emailChangeFailed ? user.email : updatedUser.email,
+        updatedUser.job_title,
+        updatedUser.phone_number,
+        updatedUser.legacyUsernames,
+        correlationId,
+      );
+
+      return res.status(500).send({ message: 'Unable to update user record, there was an error with Entra' });
+    }
   }
 
+  await sendNotification(user, updatedUser, correlationId);
   return res.status(202).send();
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,9 @@ const healthCheck = require('login.dfe.healthcheck');
 const { getErrorHandler } = require('login.dfe.express-error-handling');
 const configSchema = require('./infrastructure/config/schema');
 
+const { entraExternalAuthProvider } = require('login.dfe.entra-auth-extensions/provider');
 
-https.globalAgent.maxSockets = http.globalAgent.maxSockets =
-  config.hostingEnvironment.agentKeepAlive.maxSockets || 50;
+https.globalAgent.maxSockets = http.globalAgent.maxSockets = config.hostingEnvironment.agentKeepAlive.maxSockets || 50;
 
 configSchema.validate();
 
@@ -32,6 +32,18 @@ app.use(alwaysOnFilter());
 
 app.use('/healthcheck', healthCheck({
   config,
+}));
+
+app.use(entraExternalAuthProvider({
+  msal: {
+    cloudInstance: config.entra.cloudInstance,
+    tenantId: config.entra.tenantId,
+    clientId: config.entra.clientId,
+    clientSecret: config.entra.clientSecret,
+  },
+  graphApi: {
+    endpoint: config.entra.graphEndpoint,
+  },
 }));
 
 if (config.hostingEnvironment.useDevViews) {

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -115,11 +115,6 @@ const togglesSchema = new SimpleSchema({
 });
 
 const entraSchema = new SimpleSchema({
-  useEntraForAccountRegistration: {
-    type: Boolean,
-    optional: true,
-    defaultValue: false,
-  },
   cloudInstance: {
     type: String,
     optional: true,

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -104,13 +104,46 @@ const devicesSchema = new SimpleSchema({
 const notificationsSchema = new SimpleSchema({
   connectionString: patterns.redis,
   slackWebHookUrl: String,
-  envName: String
+  envName: String,
 });
 
 const togglesSchema = new SimpleSchema({
   notificationsEnabled: {
     type: Boolean,
     optional: true,
+  },
+});
+
+const entraSchema = new SimpleSchema({
+  useEntraForAccountRegistration: {
+    type: Boolean,
+    optional: true,
+    defaultValue: false,
+  },
+  cloudInstance: {
+    type: String,
+    optional: true,
+    defaultValue: '',
+  },
+  tenantId: {
+    type: String,
+    optional: true,
+    defaultValue: '',
+  },
+  clientId: {
+    type: String,
+    optional: true,
+    defaultValue: '',
+  },
+  clientSecret: {
+    type: String,
+    optional: true,
+    defaultValue: '',
+  },
+  graphEndpoint: {
+    type: String,
+    optional: true,
+    defaultValue: '',
   },
 });
 
@@ -128,6 +161,7 @@ const schema = new SimpleSchema({
     type: togglesSchema,
     optional: true,
   },
+  entra: entraSchema,
 });
 
 module.exports.validate = () => {

--- a/test/invitationsTests/postInvitation.test.js
+++ b/test/invitationsTests/postInvitation.test.js
@@ -177,8 +177,6 @@ describe('When creating an invitation', () => {
   it('then an invitation email is sent when the record is first created', async () => {
     await post(req, res);
 
-    console.log(sendInvitationStub.mock.calls);
-
     expect(sendInvitationStub.mock.calls[0][0]).toBe(expectedEmailAddress);
     expect(sendInvitationStub.mock.calls[0][1]).toBe(expectedFirstName);
     expect(sendInvitationStub.mock.calls[0][2]).toBe(expectedLastName);

--- a/test/invitationsTests/postResendInvitation.test.js
+++ b/test/invitationsTests/postResendInvitation.test.js
@@ -109,8 +109,6 @@ describe('When resending an invitation', () => {
 
     await post(req, res);
 
-    console.log('resget', res._getData());
-
     expect(res._getData()).toEqual({
       id: expectedInvitationId,
       email: expectedEmailAddress,

--- a/test/userCodesTests/putUpsertCode.test.js
+++ b/test/userCodesTests/putUpsertCode.test.js
@@ -139,8 +139,6 @@ describe('When getting a user code', () => {
 
     await put(req, res);
 
-    console.log('resgetdata', res._getData())
-
     expect(res._getData().code).toBe('ZXY789');
     expect(res._getData().uid).toBe('7654321');
   });

--- a/test/usertests/patchUser.test.js
+++ b/test/usertests/patchUser.test.js
@@ -3,29 +3,29 @@ jest.mock('./../../src/app/user/adapter', () => ({
   find: jest.fn(),
   update: jest.fn(),
 }));
+
 jest.mock('./../../src/utils/deprecateMiddleware', () => {
 });
-jest.mock('./../../src/infrastructure/config', () => {
-  return {
-    notifications: {
-      connectionString: 'notifications-connection-string',
-    },
-    toggles: {
-      notificationsEnabled: true,
-    },
-  };
-});
-jest.mock('./../../src/infrastructure/logger', () => {
-  return {
-    error: jest.fn(),
-    info: jest.fn(),
-  };
-});
+
+jest.mock('./../../src/infrastructure/config', () => ({
+  notifications: {
+    connectionString: 'notifications-connection-string',
+  },
+  toggles: {
+    notificationsEnabled: true,
+  },
+}));
+
+jest.mock('./../../src/infrastructure/logger', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+}));
 
 const ServiceNotificationsClient = require('login.dfe.service-notifications.jobs.client');
-const { find, update } = require('./../../src/app/user/adapter');
-const patchUser = require('./../../src/app/user/api/patchUser');
 const httpMocks = require('node-mocks-http');
+const { find, update } = require('../../src/app/user/adapter');
+const patchUser = require('../../src/app/user/api/patchUser');
+const logger = require('../../src/infrastructure/logger');
 
 const serviceNotificationsClient = {
   notifyUserUpdated: jest.fn(),
@@ -48,6 +48,10 @@ describe('When patching a user', () => {
         phone_number: '07700 900000',
         job_title: 'Manager',
         legacyUsernames: ['luser1', 'luser2'],
+      },
+      externalAuth: {
+        changeName: jest.fn(),
+        changeEmail: jest.fn(),
       },
     };
 
@@ -103,10 +107,6 @@ describe('When patching a user', () => {
     expect(update.mock.calls[0][7]).toBe('correlation-id');
   });
 
-  it('then it should update users legacy usernames in storage', async () => {
-    await patchUser(req, res);
-  });
-
   it('then it should send 400 with error message if body has unknown property', async () => {
     req.body.bad = 'value';
 
@@ -153,5 +153,148 @@ describe('When patching a user', () => {
       phone_number: '07700 900000',
       status: 1,
     });
+  });
+
+  it('should use not call any entra-auth-extensions when the user has is_entra flag and neither name or email has changed', async () => {
+    find.mockReturnValue({
+      id: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      sub: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      given_name: 'Jennifer',
+      family_name: 'Potter',
+      email: 'jenny.potter@dumbledores-army.test',
+      status: 1,
+      is_entra: true,
+      entra_oid: 'mock-entra-oid',
+    });
+
+    await patchUser(req, res);
+    expect(req.externalAuth.changeName).toHaveBeenCalledTimes(0);
+    expect(req.externalAuth.changeEmail).toHaveBeenCalledTimes(0);
+    expect(res.statusCode).toBe(202);
+  });
+
+  it('should only call entra-auth-extensions.changeName when the user has is_entra flag and only their name has changed', async () => {
+    find.mockReturnValue({
+      id: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      sub: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      given_name: 'Jennifer',
+      family_name: 'Weasley',
+      email: 'jenny.potter@dumbledores-army.test',
+      job_title: 'Manager',
+      password: 'some-hashed-data',
+      salt: 'random-salt-value',
+      status: 1,
+      is_entra: true,
+      entra_oid: 'mock-entra-oid',
+    });
+
+    await patchUser(req, res);
+    expect(req.externalAuth.changeName).toHaveBeenCalledWith({
+      userId: 'mock-entra-oid',
+      firstName: 'Jennifer',
+      lastName: 'Potter',
+    });
+
+    expect(req.externalAuth.changeEmail).toHaveBeenCalledTimes(0);
+    expect(res.statusCode).toBe(202);
+  });
+
+  it('should only call entra-auth-extensions.changeName and handle an error when the user has is_entra flag and their name has changed', async () => {
+    find.mockReturnValue({
+      id: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      sub: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      given_name: 'Jennifer',
+      family_name: 'Weasley',
+      email: 'jenny.potter@dumbledores-army.test',
+      job_title: 'Manager',
+      password: 'some-hashed-data',
+      salt: 'random-salt-value',
+      status: 1,
+      is_entra: true,
+      entra_oid: 'mock-entra-oid',
+    });
+    req.externalAuth.changeName.mockReset();
+    req.externalAuth.changeName = () => { throw new Error('mock-error'); };
+
+    await patchUser(req, res);
+
+    expect(update.mock.calls[0][0]).toBe('9b543631-884c-4b39-86d5-311ad5fc6cce');
+    expect(update.mock.calls[0][1]).toBe('Jennifer');
+    expect(update.mock.calls[0][2]).toBe('Potter');
+    expect(update.mock.calls[0][3]).toBe('jenny.potter@dumbledores-army.test');
+    expect(update.mock.calls[0][4]).toBe('Manager');
+    expect(update.mock.calls[0][5]).toBe('07700 900000');
+    expect(update.mock.calls[0][6]).toEqual(['luser1', 'luser2']);
+    expect(update.mock.calls[0][7]).toBe('correlation-id');
+
+    expect(req.externalAuth.changeEmail).toHaveBeenCalledTimes(0);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'patchUser req.externalAuth.changeName failed for user \'9b543631-884c-4b39-86d5-311ad5fc6cce\' with entraOid mock-entra-oid for the reason(s) Error: mock-error (correlationId: \'correlation-id\')',
+      { correlationId: 'correlation-id' },
+    );
+
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('should only call entra-auth-extensions.changeEmail and handle an error when the user has is_entra flag and their email has changed', async () => {
+    find.mockReturnValue({
+      id: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      sub: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      given_name: 'Jennifer',
+      family_name: 'Potter',
+      email: 'jenny.Weasley@dumbledores-army.test',
+      job_title: 'Manager',
+      password: 'some-hashed-data',
+      salt: 'random-salt-value',
+      status: 1,
+      is_entra: true,
+      entra_oid: 'mock-entra-oid',
+    });
+    req.externalAuth.changeEmail.mockReset();
+    req.externalAuth.changeEmail = () => { throw new Error('mock-error'); };
+
+    await patchUser(req, res);
+
+    expect(update.mock.calls[0][0]).toBe('9b543631-884c-4b39-86d5-311ad5fc6cce');
+    expect(update.mock.calls[0][1]).toBe('Jennifer');
+    expect(update.mock.calls[0][2]).toBe('Potter');
+    expect(update.mock.calls[0][3]).toBe('jenny.potter@dumbledores-army.test');
+    expect(update.mock.calls[0][4]).toBe('Manager');
+    expect(update.mock.calls[0][5]).toBe('07700 900000');
+    expect(update.mock.calls[0][6]).toEqual(['luser1', 'luser2']);
+    expect(update.mock.calls[0][7]).toBe('correlation-id');
+    expect(req.externalAuth.changeName).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      'patchUser req.externalAuth.changeEmail failed for user \'9b543631-884c-4b39-86d5-311ad5fc6cce\' with entraOid mock-entra-oid for the reason(s) Error: mock-error (correlationId: \'correlation-id\')',
+      { correlationId: 'correlation-id' },
+    );
+
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('should only call entra-auth-extensions.changeEmail when the user has is_entra flag and their email has changed', async () => {
+    find.mockReturnValue({
+      id: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      sub: '9b543631-884c-4b39-86d5-311ad5fc6cce',
+      given_name: 'Jennifer',
+      family_name: 'Potter',
+      email: 'jenny.weasley@dumbledores-army.test',
+      job_title: 'Manager',
+      password: 'some-hashed-data',
+      salt: 'random-salt-value',
+      status: 1,
+      is_entra: true,
+      entra_oid: 'mock-entra-oid',
+    });
+
+    await patchUser(req, res);
+    expect(req.externalAuth.changeEmail).toHaveBeenCalledWith({
+      userId: 'mock-entra-oid',
+      emailAddress: 'jenny.potter@dumbledores-army.test',
+    });
+
+    expect(req.externalAuth.changeName).toHaveBeenCalledTimes(0);
+    expect(res.statusCode).toBe(202);
   });
 });


### PR DESCRIPTION
### Summary
Jira: [DSI-7245](https://dfe-secureaccess.atlassian.net/browse/DSI-7245) - update name details in Entra
Jira: [DSI-7250](https://dfe-secureaccess.atlassian.net/browse/DSI-7250) - update email in Entra

### Changes
- Added dependency on `login.dfe.entra-auth-extensions` to access Graph API
- Resolved some lint warnings
- Modify `src/app/user/api/patchUser.js` so that if the user is entra linked
  - Call Entra if either the name or email properties are changed
  - If a call to Entra fails, then revert the changes to name or email and return error
- Add applicable unit tests for the above

### Note
- patchUser is called with either a name change or an email change, but not both.