### PR TITLE
[DSI-7294] - Bump `login.dfe.winston-appinsights` to `v5.0.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "login.dfe.public-api.jobs.client": "github:DFE-Digital/login.dfe.public-api.jobs.client#v3.0.2",
         "login.dfe.request-verification": "github:DFE-Digital/login.dfe.request-verification#v1.0.0",
         "login.dfe.service-notifications.jobs.client": "github:DFE-Digital/login.dfe.service-notifications.jobs.client#v2.0.2",
-        "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.1",
+        "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
         "mongoose": "^8.0.0",
         "path": "^0.12.7",
         "pg": "^8.11.3",
@@ -269,11 +269,12 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/functions/-/functions-4.5.1.tgz",
-      "integrity": "sha1-cNGpnTNa+HV5pV08FJ7xrnfaCmY=",
+      "version": "4.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/functions/-/functions-4.6.0.tgz",
+      "integrity": "sha1-7unKlFuKLy0HSMKABuBXF4zV+Mk=",
+      "license": "MIT",
       "dependencies": {
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.0",
         "long": "^4.0.0",
         "undici": "^5.13.0"
       },
@@ -3255,9 +3256,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha1-J5iwSwcbDsv/DbtipQWo76ThkFE=",
+      "version": "0.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6490,8 +6491,9 @@
       }
     },
     "node_modules/login.dfe.winston-appinsights": {
-      "version": "5.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#fe50b019f8bd9b065808601ef85d95d431b075ba",
+      "version": "5.0.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#e38aff47f0db953fb93f82efb3287cd66ac08799",
+      "license": "MIT",
       "dependencies": {
         "applicationinsights": "^2.0.0",
         "winston-transport": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "login.dfe.public-api.jobs.client": "github:DFE-Digital/login.dfe.public-api.jobs.client#v3.0.2",
     "login.dfe.request-verification": "github:DFE-Digital/login.dfe.request-verification#v1.0.0",
     "login.dfe.service-notifications.jobs.client": "github:DFE-Digital/login.dfe.service-notifications.jobs.client#v2.0.2",
-    "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.1",
+    "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
     "mongoose": "^8.0.0",
     "path": "^0.12.7",
     "pg": "^8.11.3",


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-7294
## Changes
- bumped `login.dfe.winston-appinsights` for masking email addresses in Application Insights when accessing the following endpoints:
 - `GET invitations/by-email/:email`
 - `GET users/:id`
