### PR TITLE
[DSI-7365] Utilise BullMQ to dispatch jobs via `jobs-client version 6.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "login.dfe.entra-auth-extensions": "^1.0.15",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
-        "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.0.1",
+        "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
         "login.dfe.password-policy": "1.0.0",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
@@ -613,6 +613,7 @@
       "version": "7.25.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
       "integrity": "sha1-Gqu3Lucu01eJtLvK08ooYs5hTow=",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -621,6 +622,7 @@
       "version": "7.25.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc=",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -651,6 +653,7 @@
       "version": "7.26.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.26.2.tgz",
       "integrity": "sha1-/XtvSHz+oJiJVX711O65/5pavRE=",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       },
@@ -928,6 +931,7 @@
       "version": "7.26.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.0.tgz",
       "integrity": "sha1-3qvQjWt1O8jg8Zj4cJ+1deMXdP8=",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1704,6 +1708,78 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha1-nt7GGyLDCCAYp59tHDAond89nRE=",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha1-M2d6J1IEiYrYrL9ic0/E3AtqSFU=",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha1-lPsFQ7ouKHZsP8Q5yrvgRArnAVk=",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha1-Ge33zcLnBj7jKEA8HYlaht0o9Ls=",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha1-SgYJq1/kTQfJxgoR5EhNPDi71uM=",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha1-CqVQLVR7V6v8SsSS3mjiAG5BckI=",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2445,14 +2521,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2484,6 +2552,7 @@
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2557,16 +2626,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "node_modules/assert-never": {
-      "version": "1.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-never/-/assert-never-1.3.0.tgz",
-      "integrity": "sha1-xTzzrY/Ntn9ACpQd6mbax/6C3S4="
-    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2609,17 +2668,6 @@
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2739,17 +2787,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-walk": {
-      "version": "3.0.0-canary-5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha1-9m7Ncpg1eu5ElV8jWm71QhkQSxE=",
-      "dependencies": {
-        "@babel/types": "^7.9.6"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/backoff": {
@@ -2958,6 +2995,20 @@
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true
     },
+    "node_modules/bullmq": {
+      "version": "5.33.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bullmq/-/bullmq-5.33.1.tgz",
+      "integrity": "sha1-/4hp7odIwc8+fRxOFP9yPQeZrWI=",
+      "dependencies": {
+        "cron-parser": "^4.6.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.11.2",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
     "node_modules/bunyan": {
       "version": "1.8.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bunyan/-/bunyan-1.8.15.tgz",
@@ -3092,14 +3143,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/character-parser": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "dependencies": {
-        "is-regex": "^1.0.3"
       }
     },
     "node_modules/chokidar": {
@@ -3249,6 +3292,7 @@
       "version": "8.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3389,15 +3433,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "node_modules/constantinople": {
-      "version": "4.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha1-De8RP6Dk3I3oMzGlz3nIsyUhMVE=",
-      "dependencies": {
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.1"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -3471,6 +3506,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha1-A0BpSvPkagiUl4xvUqbbtcDxGtU=",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.5.tgz",
@@ -3483,25 +3529,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css": {
-      "version": "2.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css/-/css-2.2.4.tgz",
-      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
-    "node_modules/css-parse": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "dependencies": {
-        "css": "^2.0.0"
       }
     },
     "node_modules/debug": {
@@ -3518,14 +3545,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek=",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/dedent": {
@@ -3606,6 +3625,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3639,11 +3667,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/doctypes": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "node_modules/dottie": {
       "version": "2.0.6",
@@ -3727,7 +3750,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true
     },
     "node_modules/enabled": {
       "version": "2.0.0",
@@ -3792,6 +3816,7 @@
       "version": "3.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4471,7 +4496,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4515,6 +4541,7 @@
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -4575,6 +4602,7 @@
       "version": "7.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4666,20 +4694,6 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4890,6 +4904,7 @@
       "version": "1.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5019,26 +5034,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-expression": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha1-wzFVliq/IdCv0lUlFNZ9LsFv0qs=",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/is-expression/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5052,6 +5047,7 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5084,26 +5080,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE="
-    },
-    "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -5824,11 +5800,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
       "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
     },
-    "node_modules/js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5925,15 +5896,6 @@
       "integrity": "sha1-xbf8f7mqdFRhkjuH3w4kfdWcfqg=",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/jstransformer": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "dependencies": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
       }
     },
     "node_modules/jwa": {
@@ -6690,10 +6652,10 @@
       }
     },
     "node_modules/login.dfe.jobs-client": {
-      "version": "6.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jobs-client.git#fe353458ce617e5665ceebf161038d7966193a77",
+      "version": "6.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jobs-client.git#0c271c49c7c91cdcea52acc148c27aaa152c0744",
       "dependencies": {
-        "login.dfe.kue": "github:DFE-Digital/login.dfe.kue#v0.12.2"
+        "bullmq": "^5.29.0"
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
@@ -6702,51 +6664,6 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^2.6.4"
-      }
-    },
-    "node_modules/login.dfe.kue": {
-      "name": "kue",
-      "version": "0.12.2",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.kue.git#a9de8984d173ce9929aa30ada24c2cd7207331c9",
-      "dependencies": {
-        "body-parser": "^1.12.2",
-        "express": "^4.12.2",
-        "lodash": "^4.0.0",
-        "nib": "~1.1.2",
-        "node-redis-warlock": "^1.0.2",
-        "pug": "^3.0.3",
-        "redis": "^3.0.0",
-        "stylus": "~0.54.5",
-        "yargs": "^17.4.1"
-      },
-      "bin": {
-        "kue-dashboard": "bin/kue-dashboard"
-      }
-    },
-    "node_modules/login.dfe.kue/node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha1-B/Zw4pyaePj67LJWah4sEZKcXL8=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/login.dfe.kue/node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha1-dmhREX6AZT0j4O1TYlRnerZHY4w=",
-      "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
       }
     },
     "node_modules/login.dfe.password-policy": {
@@ -6811,6 +6728,14 @@
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha1-a29lxc0dYdH9Gdvwfuh6UL9LjiA=",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -6961,6 +6886,7 @@
       "version": "1.2.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6969,6 +6895,7 @@
       "version": "0.5.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7109,6 +7036,35 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr/-/msgpackr-1.11.2.tgz",
+      "integrity": "sha1-RGO399aPLiSGXDlWZJc1Yq0kRz0=",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha1-6dhwI945znFIcvnpUE48GZbWEBI=",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/mv": {
       "version": "2.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mv/-/mv-2.1.1.tgz",
@@ -7185,72 +7141,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nib": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nib/-/nib-1.1.2.tgz",
-      "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "dependencies": {
-        "stylus": "0.54.5"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nib/node_modules/css-parse": {
-      "version": "1.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/css-parse/-/css-parse-1.7.0.tgz",
-      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
-    },
-    "node_modules/nib/node_modules/glob": {
-      "version": "7.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.0.6.tgz",
-      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nib/node_modules/sax": {
-      "version": "0.5.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-0.5.8.tgz",
-      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
-    },
-    "node_modules/nib/node_modules/source-map": {
-      "version": "0.1.43",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nib/node_modules/stylus": {
-      "version": "0.54.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.5.tgz",
-      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
-      "dependencies": {
-        "css-parse": "1.7.x",
-        "debug": "*",
-        "glob": "7.0.x",
-        "mkdirp": "0.5.x",
-        "sax": "0.5.x",
-        "source-map": "0.1.x"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": "*"
-      }
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -7258,6 +7152,20 @@
       "integrity": "sha1-vo2iryQ7JBfV9kancGY6krfp3tM=",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha1-Ui9QwtUxNNfzp2zXJV3kq2yWo6Q=",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -7322,28 +7230,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-redis-script": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-script/-/node-redis-script-2.0.1.tgz",
-      "integrity": "sha1-qRhOo225BPrGoM4Oe267btEHhPE="
-    },
-    "node_modules/node-redis-warlock": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-redis-warlock/-/node-redis-warlock-1.0.2.tgz",
-      "integrity": "sha1-fCVobWfTVO5gG6lLb90p9ofex2w=",
-      "dependencies": {
-        "node-redis-script": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/node-redis-warlock/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-releases": {
@@ -7426,14 +7312,6 @@
       "version": "0.9.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
@@ -7704,6 +7582,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8036,14 +7915,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/process-warning/-/process-warning-2.3.2.tgz",
       "integrity": "sha1-cNijJRqrDq/jpZXYrixdInfwlqU="
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prompts/-/prompts-2.4.2.tgz",
@@ -8074,118 +7945,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha1-wkIiT0pnwh9oaDm720rCgrg3PTo=",
       "dev": true
-    },
-    "node_modules/pug": {
-      "version": "3.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug/-/pug-3.0.3.tgz",
-      "integrity": "sha1-4YMkoxTNAiiDseA3K4rzoamfdZc=",
-      "dependencies": {
-        "pug-code-gen": "^3.0.3",
-        "pug-filters": "^4.0.0",
-        "pug-lexer": "^5.0.1",
-        "pug-linker": "^4.0.0",
-        "pug-load": "^3.0.0",
-        "pug-parser": "^6.0.0",
-        "pug-runtime": "^3.0.1",
-        "pug-strip-comments": "^2.0.0"
-      }
-    },
-    "node_modules/pug-attrs": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha1-sQRR4DSBZeMfrRzCPr3dncc0fEE=",
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "js-stringify": "^1.0.2",
-        "pug-runtime": "^3.0.0"
-      }
-    },
-    "node_modules/pug-code-gen": {
-      "version": "3.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
-      "integrity": "sha1-WBMxeMtCP+Fxauzhwdo5KnUlFSA=",
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.2",
-        "pug-attrs": "^3.0.0",
-        "pug-error": "^2.1.0",
-        "pug-runtime": "^3.0.1",
-        "void-elements": "^3.1.0",
-        "with": "^7.0.0"
-      }
-    },
-    "node_modules/pug-error": {
-      "version": "2.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-error/-/pug-error-2.1.0.tgz",
-      "integrity": "sha1-F+o3tYe2RD1LjxSDdOwntUtAblU="
-    },
-    "node_modules/pug-filters": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha1-0+Sa9bqEcum3pm2YDnB86dLMm14=",
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "jstransformer": "1.0.0",
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0",
-        "resolve": "^1.15.1"
-      }
-    },
-    "node_modules/pug-lexer": {
-      "version": "5.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha1-rkRijFvvmxkLZlaDsojKkCS4sNU=",
-      "dependencies": {
-        "character-parser": "^2.2.0",
-        "is-expression": "^4.0.0",
-        "pug-error": "^2.0.0"
-      }
-    },
-    "node_modules/pug-linker": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha1-EsvAWU/Fo+Brn8Web5PBRpYqdwg=",
-      "dependencies": {
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "node_modules/pug-load": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha1-n9nNpSICsIrbEdJWgfufNL1BtmI=",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "node_modules/pug-parser": {
-      "version": "6.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha1-qP3ANYY6lbLB3F6/Ts+AtOdqEmA=",
-      "dependencies": {
-        "pug-error": "^2.0.0",
-        "token-stream": "1.0.0"
-      }
-    },
-    "node_modules/pug-runtime": {
-      "version": "3.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha1-9jaXYgRyPzWoxfb61qzaKhkbg9c="
-    },
-    "node_modules/pug-strip-comments": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha1-+UsH/WtJVSMzD0kKf1VLT/h2MD4=",
-      "dependencies": {
-        "pug-error": "^2.0.0"
-      }
-    },
-    "node_modules/pug-walk": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha1-QXqrwpIyu0SZtbUGmistKiTV9f4="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8325,11 +8084,6 @@
         "@redis/time-series": "1.1.0"
       }
     },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha1-Fab+otWCgeJ7HNGs+0spPieMOok="
-    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -8353,6 +8107,7 @@
       "version": "2.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8416,11 +8171,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
@@ -8585,11 +8335,6 @@
       "version": "2.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -8912,20 +8657,9 @@
       "version": "0.6.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
       }
     },
     "node_modules/source-map-support": {
@@ -8937,11 +8671,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY="
     },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
@@ -9055,6 +8784,7 @@
       "version": "4.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9068,6 +8798,7 @@
       "version": "6.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9109,67 +8840,6 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha1-XE6Cn+Fa1P8NIMPbWsl7c8mwcts="
-    },
-    "node_modules/stylus": {
-      "version": "0.54.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stylus/-/stylus-0.54.8.tgz",
-      "integrity": "sha1-PaPmWWa8Vnp7BEv+DuzmU+CZ0Uc=",
-      "dependencies": {
-        "css-parse": "~2.0.0",
-        "debug": "~3.1.0",
-        "glob": "^7.1.6",
-        "mkdirp": "~1.0.4",
-        "safer-buffer": "^2.1.2",
-        "sax": "~1.2.4",
-        "semver": "^6.3.0",
-        "source-map": "^0.7.3"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/stylus/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/stylus/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stylus/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/stylus/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/stylus/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha1-qbvnBcnYhG9OCP9nZazw8bCJhlY=",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9280,11 +8950,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/token-stream": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
     },
     "node_modules/toposort-class": {
       "version": "1.0.1",
@@ -9460,11 +9125,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
     "node_modules/util": {
       "version": "0.10.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/util/-/util-0.10.4.tgz",
@@ -9575,14 +9235,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/walker/-/walker-1.0.8.tgz",
@@ -9687,20 +9339,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/with": {
-      "version": "7.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/with/-/with-7.0.2.tgz",
-      "integrity": "sha1-zO461ULSVTinp6gKrSErmChJW6w=",
-      "dependencies": {
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
-        "assert-never": "^1.2.1",
-        "babel-walk": "3.0.0-canary-5"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/wkx": {
       "version": "0.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wkx/-/wkx-0.5.0.tgz",
@@ -9722,6 +9360,7 @@
       "version": "7.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9771,6 +9410,7 @@
       "version": "5.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -9798,6 +9438,7 @@
       "version": "17.7.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -9815,6 +9456,7 @@
       "version": "21.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "login.dfe.entra-auth-extensions": "^1.0.15",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
-    "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.0.1",
+    "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
     "login.dfe.password-policy": "1.0.0",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",


### PR DESCRIPTION
### Summary
Jira: https://dfe-secureaccess.atlassian.net/browse/DSI-7417

Upgrade `login.dfe.jobs-client` to `v6.1.0` (which is build against BullMQ) so that logged jobs will be dispatched onto Redis using BullMQ.  These jobs will then be picked up by `login.dfe.jobs` and its BullMQ jobs processor.  The goal of which is remove Kue from DfE components.