### PR TITLE
[DSI-7874] Fix `/users/:uid/match-phrase` endpoint

### DIFF
--- a/src/app/user/api/matchedPassphrase.js
+++ b/src/app/user/api/matchedPassphrase.js
@@ -16,7 +16,7 @@ const matchedPassphrase = async (req, res) => {
       `perfomed a passord match  ${req.params.uid} with (reason: removed)`,
       { correlationId },
     );
-    return res.send(results);
+    return results ? res.send(results) : res.sendStatus(404);
   } catch (e) {
     logger.error(e);
     res.status(500).send(e);


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7874
___
### Changes
- Update the `/users/:uid/match-phrase` endpoint to return a `404` status if no user is found for the specified `userId`, and return a `200` status with a boolean result when the user exists and the password has been verified.
___
### Associated PRs

1. https://github.com/DFE-Digital/login.dfe.api-client/pull/24
2. https://github.com/DFE-Digital/login.dfe.interactions/pull/633