### PR TITLE
NSA- 9613-user status changes updated

### DIFF
--- a/src/app/user/api/activateUser.js
+++ b/src/app/user/api/activateUser.js
@@ -1,5 +1,22 @@
+const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
 const userAdapter = require("./../adapter");
 const logger = require("./../../../infrastructure/logger");
+const { safeUser } = require("../../../utils");
+const config = require("../../../infrastructure/config");
+
+const sendNotification = async (user, correlationId) => {
+    const serviceNotificationsClient = new ServiceNotificationsClient({
+      connectionString: config.notifications.connectionString,
+    });
+    const jobId = await serviceNotificationsClient.notifyUserUpdated(
+      safeUser(user),
+    );
+    logger.info(
+      `Send user updated notification for ${user.sub} with job id ${jobId} (reason: activate)`,
+      { correlationId },
+    );
+  };
+
 
 const changeStatus = async (req, res) => {
   try {
@@ -7,14 +24,16 @@ const changeStatus = async (req, res) => {
       return res.status(400).send();
     }
 
+    const correlationId = req.header("x-correlation-id");
     const user = await userAdapter.changeStatus(
       req.params.id,
       1,
-      req.header("x-correlation-id"),
+      correlationId,
     );
     if (!user) {
       return res.status(404).send();
     }
+    await sendNotification(user, correlationId);
     return res.send(true);
   } catch (e) {
     logger.error(e);

--- a/src/app/user/api/activateUser.js
+++ b/src/app/user/api/activateUser.js
@@ -1,22 +1,49 @@
 const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
+const {
+  getUserServicesRaw,
+  getUserOrganisationsRaw,
+} = require("login.dfe.api-client/users");
 const userAdapter = require("./../adapter");
 const logger = require("./../../../infrastructure/logger");
 const { safeUser } = require("../../../utils");
 const config = require("../../../infrastructure/config");
 
-const sendNotification = async (user, correlationId) => {
-    const serviceNotificationsClient = new ServiceNotificationsClient({
-      connectionString: config.notifications.connectionString,
-    });
-    const jobId = await serviceNotificationsClient.notifyUserUpdated(
-      safeUser(user),
-    );
-    logger.info(
-      `Send user updated notification for ${user.sub} with job id ${jobId} (reason: activate)`,
+// The organisations API filters by user.status, so we capture the snapshot
+// AFTER activation (when the user is visible again) and ship it inside the
+// notification — keeps downstream jobs from doing a live lookup.
+const captureUserAccessSnapshot = async (userId, correlationId) => {
+  try {
+    const [userServices, userOrganisations] = await Promise.all([
+      getUserServicesRaw({ userId }),
+      getUserOrganisationsRaw({ userId }),
+    ]);
+    return {
+      userServices: userServices || [],
+      userOrganisations: userOrganisations || [],
+    };
+  } catch (e) {
+    logger.warn(
+      `Failed to capture user access snapshot for ${userId} after activation: ${e.message}`,
       { correlationId },
     );
-  };
+    return { userServices: [], userOrganisations: [] };
+  }
+};
 
+const sendNotification = async (user, accessSnapshot, correlationId) => {
+  const serviceNotificationsClient = new ServiceNotificationsClient({
+    connectionString: config.notifications.connectionString,
+  });
+  const jobId = await serviceNotificationsClient.notifyUserUpdated({
+    ...safeUser(user),
+    userServices: accessSnapshot.userServices,
+    userOrganisations: accessSnapshot.userOrganisations,
+  });
+  logger.info(
+    `Send user updated notification for ${user.sub} with job id ${jobId} (reason: activate)`,
+    { correlationId },
+  );
+};
 
 const changeStatus = async (req, res) => {
   try {
@@ -33,7 +60,13 @@ const changeStatus = async (req, res) => {
     if (!user) {
       return res.status(404).send();
     }
-    await sendNotification(user, correlationId);
+
+    const accessSnapshot = await captureUserAccessSnapshot(
+      req.params.id,
+      correlationId,
+    );
+
+    await sendNotification(user, accessSnapshot, correlationId);
     return res.send(true);
   } catch (e) {
     logger.error(e);

--- a/src/app/user/api/deactivateUser.js
+++ b/src/app/user/api/deactivateUser.js
@@ -1,21 +1,49 @@
 const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
+const {
+  getUserServicesRaw,
+  getUserOrganisationsRaw,
+} = require("login.dfe.api-client/users");
 const userAdapter = require("./../adapter");
 const logger = require("./../../../infrastructure/logger");
 const { safeUser } = require("../../../utils");
 const config = require("../../../infrastructure/config");
 
-const sendNotification = async (user, correlationId) => {
-    const serviceNotificationsClient = new ServiceNotificationsClient({
-      connectionString: config.notifications.connectionString,
-    });
-    const jobId = await serviceNotificationsClient.notifyUserUpdated(
-      safeUser(user),
-    );
-    logger.info(
-      `Send user updated notification for ${user.sub} with job id ${jobId} (reason: deactivate)`,
+// The organisations API filters by user.status, so once we deactivate the user
+// a live lookup from downstream jobs returns nothing. Capture the snapshot now
+// (while the user is still active) and ship it inside the notification.
+const captureUserAccessSnapshot = async (userId, correlationId) => {
+  try {
+    const [userServices, userOrganisations] = await Promise.all([
+      getUserServicesRaw({ userId }),
+      getUserOrganisationsRaw({ userId }),
+    ]);
+    return {
+      userServices: userServices || [],
+      userOrganisations: userOrganisations || [],
+    };
+  } catch (e) {
+    logger.warn(
+      `Failed to capture user access snapshot for ${userId} prior to deactivation: ${e.message}`,
       { correlationId },
     );
-  };
+    return { userServices: [], userOrganisations: [] };
+  }
+};
+
+const sendNotification = async (user, accessSnapshot, correlationId) => {
+  const serviceNotificationsClient = new ServiceNotificationsClient({
+    connectionString: config.notifications.connectionString,
+  });
+  const jobId = await serviceNotificationsClient.notifyUserUpdated({
+    ...safeUser(user),
+    userServices: accessSnapshot.userServices,
+    userOrganisations: accessSnapshot.userOrganisations,
+  });
+  logger.info(
+    `Send user updated notification for ${user.sub} with job id ${jobId} (reason: deactivate)`,
+    { correlationId },
+  );
+};
 
 const changeStatus = async (req, res) => {
   try {
@@ -23,6 +51,12 @@ const changeStatus = async (req, res) => {
       return res.status(400).send();
     }
     const correlation_id = req.header("x-correlation-id");
+
+    // MUST run before changeStatus — once status flips to 0 the API hides access.
+    const accessSnapshot = await captureUserAccessSnapshot(
+      req.params.id,
+      correlation_id,
+    );
 
     const user = await userAdapter.changeStatus(
       req.params.id,
@@ -42,7 +76,7 @@ const changeStatus = async (req, res) => {
         correlation_id,
       );
     }
-    await sendNotification(user, correlation_id);
+    await sendNotification(user, accessSnapshot, correlation_id);
     return res.send(true);
   } catch (e) {
     logger.error(e);

--- a/src/app/user/api/deactivateUser.js
+++ b/src/app/user/api/deactivateUser.js
@@ -1,5 +1,21 @@
+const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
 const userAdapter = require("./../adapter");
 const logger = require("./../../../infrastructure/logger");
+const { safeUser } = require("../../../utils");
+const config = require("../../../infrastructure/config");
+
+const sendNotification = async (user, correlationId) => {
+    const serviceNotificationsClient = new ServiceNotificationsClient({
+      connectionString: config.notifications.connectionString,
+    });
+    const jobId = await serviceNotificationsClient.notifyUserUpdated(
+      safeUser(user),
+    );
+    logger.info(
+      `Send user updated notification for ${user.sub} with job id ${jobId} (reason: deactivate)`,
+      { correlationId },
+    );
+  };
 
 const changeStatus = async (req, res) => {
   try {
@@ -26,6 +42,7 @@ const changeStatus = async (req, res) => {
         correlation_id,
       );
     }
+    await sendNotification(user, correlation_id);
     return res.send(true);
   } catch (e) {
     logger.error(e);

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,12 @@ setupApi({
     applications: {
       baseUri: config.applications.service.url,
     },
+    access: {
+      baseUri: config.access.service.url,
+    },
+    organisations: {
+      baseUri: config.organisations.service.url,
+    },
   },
 });
 

--- a/src/infrastructure/config/index.js
+++ b/src/infrastructure/config/index.js
@@ -108,6 +108,34 @@ const config = {
       }
     }
   },
+  access: {
+    type: "api",
+    service: {
+      url: "https://" + process.env.STANDALONE_ACCESS_HOST_NAME,
+      auth: {
+        type: "aad",
+        tenant: process.env.PLATFORM_GLOBAL_TENANT_DOMAIN,
+        authorityHostUrl: process.env.TENANT_URL,
+        clientId: process.env.AAD_SHD_CLIENT_ID,
+        clientSecret: process.env.AAD_SHD_CLIENT_SECRET,
+        resource: process.env.AAD_SHD_APP_ID
+      }
+    }
+  },
+  organisations: {
+    type: "api",
+    service: {
+      url: "https://" + process.env.STANDALONE_ORGANISATIONS_HOST_NAME,
+      auth: {
+        type: "aad",
+        tenant: process.env.PLATFORM_GLOBAL_TENANT_DOMAIN,
+        authorityHostUrl: process.env.TENANT_URL,
+        clientId: process.env.AAD_SHD_CLIENT_ID,
+        clientSecret: process.env.AAD_SHD_CLIENT_SECRET,
+        resource: process.env.AAD_SHD_APP_ID
+      }
+    }
+  },
   auth: {
     type: "aad",
     identityMetadata: process.env.TENANT_URL + "/.well-known/openid-configuration",

--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -120,6 +120,8 @@ const schema = new SimpleSchema({
   userCodes: userCodesSchema,
   invitations: invitationsSchema,
   applications: schemas.apiClient,
+  access: schemas.apiClient,
+  organisations: schemas.apiClient,
   auth: schemas.apiServerAuth,
   notifications: notificationsSchema,
   toggles: {

--- a/test/usertests/UserRedisAdapter.test.js
+++ b/test/usertests/UserRedisAdapter.test.js
@@ -189,8 +189,14 @@ describe("When using redis storage service", () => {
       );
 
       expect(actual).toBe(true);
+      // The adapter does not await client.set, so on Node 23 the write to
+      // ioredis-mock can resolve after our follow-up read. Flush pending
+      // microtasks/immediates before reading the updated user.
+      await new Promise((resolve) => setImmediate(resolve));
       const findResult = await userStorage.find("test3@localuser.com");
       expect(findResult).not.toBeNull();
+      expect(findResult.salt).toBeDefined();
+      expect(findResult.password).toBeDefined();
       const request = promisify(crypto.pbkdf2);
       const saltBuffer = Buffer.from(findResult.salt, "utf8");
       const derivedKey = await request(
@@ -201,7 +207,7 @@ describe("When using redis storage service", () => {
         "sha512",
       );
       expect(findResult.password).toBe(derivedKey.toString("base64"));
-    });
+    }, 30000);
   });
   describe("then when i call create", () => {
     beforeEach(() => {

--- a/test/usertests/getUserStatus.test.js
+++ b/test/usertests/getUserStatus.test.js
@@ -1,5 +1,8 @@
+jest.mock("login.dfe.jobs-client");
 const httpMocks = require("node-mocks-http");
 const getUserStatus = require("../../src/app/user/api/getUserStatus");
+const activateUser = require("../../src/app/user/api/activateUser");
+const deactivateUser = require("../../src/app/user/api/deactivateUser");
 
 jest.mock("../../src/infrastructure/logger", () => ({
   info: jest.fn(),
@@ -11,15 +14,36 @@ jest.mock("./../../src/app/user/adapter", () => {
     .fn()
     .mockImplementation(() => undefined);
   const find = jest.fn().mockImplementation(() => undefined);
+  const changeStatus = jest.fn().mockImplementation(() => undefined);
+  const createUserStatusChangeReason = jest
+    .fn()
+    .mockImplementation(() => undefined);
   return {
     find: jest.fn().mockImplementation(find),
+    changeStatus: jest.fn().mockImplementation(changeStatus),
+    createUserStatusChangeReason: jest
+      .fn()
+      .mockImplementation(createUserStatusChangeReason),
     findUserStatusChangeReasons: jest
       .fn()
       .mockImplementation(findUserStatusChangeReasons),
   };
 });
 
+jest.mock("./../../src/infrastructure/config", () => ({
+  notifications: {
+    connectionString: "notifications-connection-string",
+  },
+}));
+
 const adapter = require("../../src/app/user/adapter");
+const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
+const logger = require("../../src/infrastructure/logger");
+
+const serviceNotificationsClient = {
+  notifyUserUpdated: jest.fn(),
+};
+
 const user = {
   sub: "78071717-4247-480d-90a3-3d531379ebf8",
   email: "bob@bob.com",
@@ -127,6 +151,162 @@ describe("When calling the getStatus endpoint", () => {
 
     await getUserStatus(req, res);
 
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("When activating a user", () => {
+  let req;
+  let res;
+  const expectedRequestCorrelationId = "some-correlation-id";
+
+  beforeEach(() => {
+    req = {
+      header: () => expectedRequestCorrelationId,
+      params: {
+        id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      },
+    };
+    res = httpMocks.createResponse();
+
+    adapter.changeStatus.mockReset();
+    adapter.changeStatus.mockResolvedValue({
+      id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      sub: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      given_name: "Test",
+      family_name: "Tester",
+      email: "test@local",
+      job_title: "Manager",
+      status: 1,
+    });
+
+    serviceNotificationsClient.notifyUserUpdated.mockReset();
+    serviceNotificationsClient.notifyUserUpdated.mockResolvedValue("job-id");
+    ServiceNotificationsClient.mockReset().mockImplementation(
+      () => serviceNotificationsClient,
+    );
+
+    logger.error.mockReset();
+  });
+
+  it("then it notifies when the user is updated", async () => {
+    await activateUser(req, res);
+
+    expect(adapter.changeStatus).toHaveBeenCalledWith(
+      "a516696c-168c-4680-8dfb-1512d6fc234c",
+      1,
+      expectedRequestCorrelationId,
+    );
+    expect(ServiceNotificationsClient).toHaveBeenCalledWith({
+      connectionString: "notifications-connection-string",
+    });
+    expect(serviceNotificationsClient.notifyUserUpdated).toHaveBeenCalledWith({
+      id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      sub: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      given_name: "Test",
+      family_name: "Tester",
+      email: "test@local",
+      job_title: "Manager",
+      status: 1,
+    });
+  });
+
+  it("then it returns 500 if notification fails", async () => {
+    const expectedError = new Error("notification failed");
+    serviceNotificationsClient.notifyUserUpdated.mockRejectedValue(
+      expectedError,
+    );
+
+    await activateUser(req, res);
+
+    expect(serviceNotificationsClient.notifyUserUpdated).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(logger.error).toHaveBeenCalledWith(expectedError);
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("When deactivating a user", () => {
+  let req;
+  let res;
+  const expectedRequestCorrelationId = "some-correlation-id";
+
+  beforeEach(() => {
+    req = {
+      header: () => expectedRequestCorrelationId,
+      params: {
+        id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      },
+      body: {
+        reason: "Deactivation reason",
+      },
+    };
+    res = httpMocks.createResponse();
+
+    adapter.changeStatus.mockReset();
+    adapter.changeStatus.mockResolvedValue({
+      id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      sub: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      given_name: "Test",
+      family_name: "Tester",
+      email: "test@local",
+      job_title: "Manager",
+      status: 0,
+    });
+    adapter.createUserStatusChangeReason.mockReset();
+    adapter.createUserStatusChangeReason.mockResolvedValue(undefined);
+
+    serviceNotificationsClient.notifyUserUpdated.mockReset();
+    serviceNotificationsClient.notifyUserUpdated.mockResolvedValue("job-id");
+    ServiceNotificationsClient.mockReset().mockImplementation(
+      () => serviceNotificationsClient,
+    );
+
+    logger.error.mockReset();
+  });
+
+  it("then it notifies when the user is updated", async () => {
+    await deactivateUser(req, res);
+
+    expect(adapter.changeStatus).toHaveBeenCalledWith(
+      "a516696c-168c-4680-8dfb-1512d6fc234c",
+      0,
+      expectedRequestCorrelationId,
+    );
+    expect(adapter.createUserStatusChangeReason).toHaveBeenCalledWith(
+      "a516696c-168c-4680-8dfb-1512d6fc234c",
+      1,
+      0,
+      "Deactivation reason",
+      expectedRequestCorrelationId,
+    );
+    expect(ServiceNotificationsClient).toHaveBeenCalledWith({
+      connectionString: "notifications-connection-string",
+    });
+    expect(serviceNotificationsClient.notifyUserUpdated).toHaveBeenCalledWith({
+      id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      sub: "a516696c-168c-4680-8dfb-1512d6fc234c",
+      given_name: "Test",
+      family_name: "Tester",
+      email: "test@local",
+      job_title: "Manager",
+      status: 0,
+    });
+  });
+
+  it("then it returns 500 if notification fails", async () => {
+    const expectedError = new Error("notification failed");
+    serviceNotificationsClient.notifyUserUpdated.mockRejectedValue(
+      expectedError,
+    );
+
+    await deactivateUser(req, res);
+
+    expect(serviceNotificationsClient.notifyUserUpdated).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(logger.error).toHaveBeenCalledWith(expectedError);
     expect(res.statusCode).toBe(500);
   });
 });

--- a/test/usertests/getUserStatus.test.js
+++ b/test/usertests/getUserStatus.test.js
@@ -1,11 +1,20 @@
 jest.mock("login.dfe.jobs-client");
+jest.mock("login.dfe.api-client/users", () => ({
+  getUserServicesRaw: jest.fn(),
+  getUserOrganisationsRaw: jest.fn(),
+}));
 const httpMocks = require("node-mocks-http");
 const getUserStatus = require("../../src/app/user/api/getUserStatus");
 const activateUser = require("../../src/app/user/api/activateUser");
 const deactivateUser = require("../../src/app/user/api/deactivateUser");
+const {
+  getUserServicesRaw,
+  getUserOrganisationsRaw,
+} = require("login.dfe.api-client/users");
 
 jest.mock("../../src/infrastructure/logger", () => ({
   info: jest.fn(),
+  warn: jest.fn(),
   error: jest.fn(),
 }));
 
@@ -186,10 +195,24 @@ describe("When activating a user", () => {
       () => serviceNotificationsClient,
     );
 
+    getUserServicesRaw.mockReset().mockResolvedValue([
+      {
+        serviceId: "service1",
+        organisationId: "organisation1",
+        roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+      },
+    ]);
+    getUserOrganisationsRaw.mockReset().mockResolvedValue([
+      {
+        organisation: { id: "organisation1", legacyId: 123 },
+        numericIdentifier: "sauser1",
+      },
+    ]);
+
     logger.error.mockReset();
   });
 
-  it("then it notifies when the user is updated", async () => {
+  it("then it notifies when the user is updated, including the access snapshot", async () => {
     await activateUser(req, res);
 
     expect(adapter.changeStatus).toHaveBeenCalledWith(
@@ -197,6 +220,12 @@ describe("When activating a user", () => {
       1,
       expectedRequestCorrelationId,
     );
+    expect(getUserServicesRaw).toHaveBeenCalledWith({
+      userId: "a516696c-168c-4680-8dfb-1512d6fc234c",
+    });
+    expect(getUserOrganisationsRaw).toHaveBeenCalledWith({
+      userId: "a516696c-168c-4680-8dfb-1512d6fc234c",
+    });
     expect(ServiceNotificationsClient).toHaveBeenCalledWith({
       connectionString: "notifications-connection-string",
     });
@@ -208,6 +237,19 @@ describe("When activating a user", () => {
       email: "test@local",
       job_title: "Manager",
       status: 1,
+      userServices: [
+        {
+          serviceId: "service1",
+          organisationId: "organisation1",
+          roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+        },
+      ],
+      userOrganisations: [
+        {
+          organisation: { id: "organisation1", legacyId: 123 },
+          numericIdentifier: "sauser1",
+        },
+      ],
     });
   });
 
@@ -263,12 +305,51 @@ describe("When deactivating a user", () => {
       () => serviceNotificationsClient,
     );
 
+    getUserServicesRaw.mockReset().mockResolvedValue([
+      {
+        serviceId: "service1",
+        organisationId: "organisation1",
+        roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+      },
+    ]);
+    getUserOrganisationsRaw.mockReset().mockResolvedValue([
+      {
+        organisation: { id: "organisation1", legacyId: 123 },
+        numericIdentifier: "sauser1",
+      },
+    ]);
+
     logger.error.mockReset();
   });
 
-  it("then it notifies when the user is updated", async () => {
+  it("then it notifies when the user is updated, including the access snapshot captured before deactivation", async () => {
+    const callOrder = [];
+    getUserServicesRaw.mockImplementationOnce(async () => {
+      callOrder.push("snapshot");
+      return [
+        {
+          serviceId: "service1",
+          organisationId: "organisation1",
+          roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+        },
+      ];
+    });
+    adapter.changeStatus.mockImplementationOnce(async () => {
+      callOrder.push("changeStatus");
+      return {
+        id: "a516696c-168c-4680-8dfb-1512d6fc234c",
+        sub: "a516696c-168c-4680-8dfb-1512d6fc234c",
+        given_name: "Test",
+        family_name: "Tester",
+        email: "test@local",
+        job_title: "Manager",
+        status: 0,
+      };
+    });
+
     await deactivateUser(req, res);
 
+    expect(callOrder).toEqual(["snapshot", "changeStatus"]);
     expect(adapter.changeStatus).toHaveBeenCalledWith(
       "a516696c-168c-4680-8dfb-1512d6fc234c",
       0,
@@ -292,6 +373,19 @@ describe("When deactivating a user", () => {
       email: "test@local",
       job_title: "Manager",
       status: 0,
+      userServices: [
+        {
+          serviceId: "service1",
+          organisationId: "organisation1",
+          roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+        },
+      ],
+      userOrganisations: [
+        {
+          organisation: { id: "organisation1", legacyId: 123 },
+          numericIdentifier: "sauser1",
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
Activate/deactivate user endpoints now emit a userupdated_v1 notification with the user's services and organisations embedded in the payload. For deactivation the snapshot is captured before the status flip (since the org API hides deactivated users); for activation it's captured after. Snapshot failures are logged and fall back to empty arrays; notification failures return 500. Includes new tests covering both flows.